### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following variables to your Lita config file:
 ``` ruby
 config.handlers.yelpme.consumer_secret = 'CONSUMER_SECRET'
 config.handlers.yelpme.consumer_key = 'CONSUMER_KEY'
-config.handlers.yelpme.token_key = 'TOKEN_KEY'
+config.handlers.yelpme.token = 'TOKEN_KEY'
 config.handlers.yelpme.token_secret = 'TOKEN_SECRET'
 ```
 


### PR DESCRIPTION
I had issues setting this up in lita until I took a look at the yelp-ruby gem as well at the the lita-yelpme configuration [here](https://github.com/twexler/lita-yelpme/blob/master/lib/lita/handlers/yelpme.rb#L53-Lundefined)

It's expecting token not token_key.
